### PR TITLE
Make compatible with HDRP 6.7.x

### DIFF
--- a/BakeryHDRP_Forward.hlsl
+++ b/BakeryHDRP_Forward.hlsl
@@ -46,7 +46,7 @@ void Frag(PackedVaryingsToPS packedInput,
 #endif
 
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput_Stereo(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz, tileIndex, unity_StereoEyeIndex);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz, tileIndex);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);


### PR DESCRIPTION
In HDRP 6.7.0, GetPositionInput_Stereo was removed. GetPositionInput has to be used instead.